### PR TITLE
Fix unit tests to improve coverage

### DIFF
--- a/tests/entity.test.js
+++ b/tests/entity.test.js
@@ -10,21 +10,59 @@ const Entity = require('../src/entity');
 
 const dummies = require('./fixtures/dummies');
 
-test('Expose basic properties', () => {
-    const entity = new Entity({
-        id: 684,
+/**
+ * Return default entity definition to be used in tests
+ * @return {object}
+ */
+function createEntityDefinition() {
+    return {
+        id: '684',
         name: 'foo',
-        type: 'bar',
+        type: 'foo-bar',
         config: {
             foo: 'bar',
         },
-    }, dummies.createSandbox(), dummies.winston);
+    };
+}
 
-    expect(entity.id).toBe(684);
+/**
+ * Return an entity to be used in tests
+ * @param {*} sandbox
+ * @return {Entity}
+ */
+function createEntity(sandbox) {
+    return new Entity(createEntityDefinition(), sandbox, dummies.winston);
+}
+
+test('Expose basic properties', () => {
+    const entity = createEntity(dummies.createSandbox());
+
+    expect(entity.id).toBe('684');
     expect(entity.name).toBe('foo');
-    expect(entity.type).toBe('bar');
+    expect(entity.type).toBe('foo-bar');
     expect(entity.config.foo).toBe('bar');
+});
 
-    // todo: Properly define and adopt this entity into a platform
-    // entity.setProperty('foo', 'bar');
+test('Call sandbox functions', () => {
+    const sandbox = dummies.createSandbox();
+    const entityDefinition = createEntityDefinition();
+    delete entityDefinition['config'];
+
+    const ps = jest.fn();
+    process.send = ps;
+
+    sandbox.on('adopt', (entity) => {
+        entity.setProperty('foo', 'bar');
+        expect(ps).toHaveBeenCalledWith({name: 'pendingChanges', args: {entityIds: ['684']}});
+        ps.mockReset();
+
+        entity.setAttribute('foo', 'bar');
+        expect(ps).toHaveBeenCalledWith({name: 'pendingChanges', args: {entityIds: ['684']}});
+        ps.mockReset();
+
+        sandbox.processChangeQueue();
+        expect(ps).toHaveBeenCalledWith({name: 'data', args: {attributes: {foo: 'bar'}, entityId: '684', properties: {foo: 'bar'}}});
+        ps.mockReset();
+    });
+    sandbox.adopt(entityDefinition);
 });


### PR DESCRIPTION
Extend the unit tests to improve the coverage of the separate parts of the platform and fix the lowered coverage after implementing the data pass through.